### PR TITLE
Add read-only option for organization-owned repos

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 # Some sane defaults provided
+NEXT_PUBLIC_URL="http://localhost:3000"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="NpUFdWakhCjbuIIogCvj"
 GITHUB_CLIENT_ID=""

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm run dev
 
 ## Environment variables
 
-1. `NEXTAUTH_URL`: Site link, `http://localhost:3000` if developing locally, `https://gaterepo.com` for this deployed instance
+1. `NEXTAUTH_URL` and `NEXT_PUBLIC_URL`: Set both as site link, `http://localhost:3000` if developing locally, `https://gaterepo.com` for this deployed instance
 2. `NEXTAUTH_SECRET`: Any randomly generated string as a secret, e.g.: `NpUFdWakhCjbuIIogCvj`
 3. `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`: Follow the instructions [here](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) for spinning up a new GitHub OAuth application. When asked, the authorization callback URL is `http://localhost:3000/api/auth/callback/github` (local) or `https://your_domain.com/api/auth/callback/github` (deployed). Once setup, your OAuth applications `Client ID` is your `GITHUB_CLIENT_ID` and your `Client Secret` is your `GITHUB_CLIENT_SECRET`
 4. `DATABASE_URL`: Postgres database connection URL

--- a/pages/api/gates/access.ts
+++ b/pages/api/gates/access.ts
@@ -98,7 +98,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     address, // Ethereum address with tokens
     signature, // Signature verifying Ethereum address ownership
     gateId, // Gated repo ID
-  }: { address: string; signature: string; gateId: string } = req.body;
+    readOnly, // Read-only permission
+  }: { address: string; signature: string; gateId: string; readOnly: boolean } =
+    req.body;
   if (!address || !signature || !gateId) {
     res.status(500).send({ error: "Missing parameters." });
     return;
@@ -230,6 +232,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       owner: gate.repoOwner,
       repo: gate.repoName,
       username,
+      permission: readOnly ? "pull" : undefined,
     });
     // If invitation id exists, update variable
     if (id) invitationId = id;

--- a/pages/api/gates/create.ts
+++ b/pages/api/gates/create.ts
@@ -46,6 +46,7 @@ const getERC20Details = async (
  * @param {string} contract address
  * @param {number} numTokens count
  * @param {number} numInvites count
+ * @param {boolean} readOnly permission
  * @returns {Promise<string>} gated repository id
  */
 const createGatedRepo = async (
@@ -54,7 +55,8 @@ const createGatedRepo = async (
   repo: string,
   contract: string,
   numTokens: number,
-  numInvites: number
+  numInvites: number,
+  readOnly: boolean
 ): Promise<string> => {
   // Check if you have permission to repo
   const repository: Repo = await getRepo(userId, owner, repo);
@@ -76,6 +78,7 @@ const createGatedRepo = async (
       contractDecimals: decimals,
       numTokens,
       numInvites,
+      readOnly,
       creator: {
         connect: {
           id: userId,
@@ -104,12 +107,14 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     contract,
     tokens,
     invites,
+    readOnly,
   }: {
     owner: string;
     repo: string;
     contract: string;
     tokens: number;
     invites: number;
+    readOnly: boolean;
   } = req.body;
   if (!owner || !repo || !isValidAddress(contract) || !tokens || !invites) {
     res.status(500).send({ error: "Missing parameters." });
@@ -124,7 +129,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       repo,
       contract,
       tokens,
-      invites
+      invites,
+      readOnly
     );
     res.status(200).send({ id: gateId });
   } catch (e) {

--- a/pages/api/github/repo.ts
+++ b/pages/api/github/repo.ts
@@ -54,9 +54,12 @@ export const getRepo = async (
     throw new Error("Repo does not exist or no access.");
   }
 
+  const isOrg = repository.owner.type === "Organization";
+
   return {
     fullName: repository.full_name,
     htmlURL: repository.html_url,
+    isOrg,
   };
 };
 

--- a/pages/api/github/repos.ts
+++ b/pages/api/github/repos.ts
@@ -7,6 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 export type Repo = {
   fullName: string;
   htmlURL: string;
+  isOrg: boolean;
 };
 
 /**
@@ -72,11 +73,13 @@ export const getRepos = async (userId: string): Promise<Repo[]> => {
     if (repo.full_name in repoExist) {
       continue;
     }
+    const isOrg = repo.owner.type === "Organization";
 
     if (!repo.archived && !repo.disabled && repo.permissions?.admin) {
       repos.push({
         fullName: repo.full_name,
         htmlURL: repo.html_url,
+        isOrg,
       });
       // Update duplicates check
       repoExist[repo.full_name] = true;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -245,6 +245,11 @@ function IndividualGate({
             #{formatNumber(gate.blockNumber)}
           </a>
         </p>
+        {gate.readOnly ? (
+          <p>
+            <strong>Permission:</strong> Read-only
+          </p>
+        ) : null}
       </div>
 
       {/* Actions */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -188,8 +188,9 @@ function IndividualGate({
    * @param {string} gateId to copy
    */
   const copyInvite = (gateId: string) => {
+    const domain = process.env.NEXT_PUBLIC_URL;
     // Copy to clipboard
-    navigator.clipboard.writeText(`https://gaterepo.com/repo/join/${gateId}`);
+    navigator.clipboard.writeText(`${domain}/repo/join/${gateId}`);
 
     // Update button
     setCopyText("Copied!");

--- a/pages/repo/create/[owner]/[repo].tsx
+++ b/pages/repo/create/[owner]/[repo].tsx
@@ -45,6 +45,7 @@ export default function Create({
   const [numTokens, setNumTokens] = useState<number>(1); // Number of required tokens
   const [loading, setLoading] = useState<boolean>(false); // Loading
   const [numParticipants, setNumParticipants] = useState<number>(10); // Maximum invite count
+  const [readOnly, setReadOnly] = useState<boolean>(false); // Read only permission
 
   // Input validation
   const invalidAddress: boolean = !isValidAddress(address);
@@ -66,6 +67,7 @@ export default function Create({
         contract: address,
         tokens: numTokens,
         invites: numParticipants,
+        readOnly,
       });
       // Copy invite to clipboard
       navigator.clipboard.writeText(`https://gaterepo.com/repo/join/${id}`);
@@ -127,6 +129,19 @@ export default function Create({
             value={numParticipants}
             onChange={(e) => setNumParticipants(Number(e.target.value))}
           />
+
+          {/* Read only permission - Show only if repo is owned by org */}
+          {repo.isOrg ? (
+            <>
+              <label htmlFor="readOnly">Enable read-only access</label>
+              <input
+                id="readOnly"
+                type="checkbox"
+                checked={readOnly}
+                onChange={() => setReadOnly(!readOnly)}
+              />{" "}
+            </>
+          ) : null}
 
           {/* Create gated repository */}
           <button

--- a/pages/repo/create/[owner]/[repo].tsx
+++ b/pages/repo/create/[owner]/[repo].tsx
@@ -133,13 +133,15 @@ export default function Create({
           {/* Read only permission - Show only if repo is owned by org */}
           {repo.isOrg ? (
             <>
-              <label htmlFor="readOnly">Enable read-only access</label>
-              <input
-                id="readOnly"
-                type="checkbox"
-                checked={readOnly}
-                onChange={() => setReadOnly(!readOnly)}
-              />{" "}
+              <label htmlFor="readOnly" className={styles.checkbox}>
+                <input
+                  id="readOnly"
+                  type="checkbox"
+                  checked={readOnly}
+                  onChange={() => setReadOnly(!readOnly)}
+                />
+                Read-only access
+              </label>
             </>
           ) : null}
 

--- a/pages/repo/create/[owner]/[repo].tsx
+++ b/pages/repo/create/[owner]/[repo].tsx
@@ -69,8 +69,9 @@ export default function Create({
         invites: numParticipants,
         readOnly,
       });
+      const domain = process.env.NEXT_PUBLIC_URL;
       // Copy invite to clipboard
-      navigator.clipboard.writeText(`https://gaterepo.com/repo/join/${id}`);
+      navigator.clipboard.writeText(`${domain}/repo/join/${id}`);
 
       // Toast and return to home
       toast.success("Successfully created gated repository. Invite copied.");

--- a/pages/repo/join/[id].tsx
+++ b/pages/repo/join/[id].tsx
@@ -24,6 +24,7 @@ export default function Join({ gate }: { gate: GateExtended }) {
   const [connectionStarted, setConnectionStarted] = useState<boolean>(false);
   // Web3React setup
   const { active, account, activate, deactivate, library } = useWeb3React();
+  const domain = process.env.NEXT_PUBLIC_URL;
 
   // Templated content
   const templateDescription: string = gate.creator.name
@@ -135,7 +136,7 @@ export default function Join({ gate }: { gate: GateExtended }) {
       <Meta
         title={`GateRepo - @${gate.repoOwner}/${gate.repoName}`}
         description={templateDescription}
-        url={`https://gaterepo.com/repo/join/${gate.id}`}
+        url={`${domain}/repo/join/${gate.id}`}
       />
 
       {/* Logo */}

--- a/pages/repo/join/[id].tsx
+++ b/pages/repo/join/[id].tsx
@@ -108,6 +108,7 @@ export default function Join({ gate }: { gate: GateExtended }) {
         address: account,
         signature,
         gateId: gate.id,
+        readOnly: gate.readOnly,
       });
 
       // If successful, toast and redirect

--- a/prisma/migrations/20220412232557_add_read_only_to_gate/migration.sql
+++ b/prisma/migrations/20220412232557_add_read_only_to_gate/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `readOnly` to the `Gate` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Gate" ADD COLUMN     "readOnly" BOOLEAN NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Gate {
   contractDecimals Int
   numTokens        Float
   numInvites       Int
+  readOnly         Boolean
   usedInvites      Int    @default(0)
   creator          User   @relation(fields: [creatorId], references: [id])
 }

--- a/styles/pages/Create.module.scss
+++ b/styles/pages/Create.module.scss
@@ -65,4 +65,9 @@
       background-color: var(--color-button-green-disabled-bg);
     }
   }
+
+  .checkbox {
+    display: flex;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
When giving access to repos owned by an organisation, new members get "write" access by default. This may be undesirable.

- Added read-only option during gate creation (only shows up if repo is owned by an org)
- Added readOnly to Gate in db schema
- Added frontend elements related to read-only option
- Changed .env.sample and readme
- Fixed links that were hardcoded to 'gaterepo.com'

Btw great work doing this, love this project ❤️